### PR TITLE
Fixed resources/categories.json's keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "tamabotchi",
-  "version": "0.0.1",
-  "description": "A tamabotchi",
-  "main": "tamabotchi.js",
+  "version": "0.2.0",
+  "description": "A facebook chatbot for trivia games",
+  "main": "app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/resources/categories.json
+++ b/resources/categories.json
@@ -69,19 +69,19 @@
                     "key": "General Knowledge"
                 }, {
                     "title": "Sports",
-                    "key": "General Knowledge"
+                    "key": "Sports"
                 }, {
                     "title": "Politics",
-                    "key": "General Knowledge"
+                    "key": "Politics"
                 }, {
                     "title": "Art",
-                    "key": "General Knowledge"
+                    "key": "Art"
                 }, {
                     "title": "Celebrities",
-                    "key": "General Knowledge"
+                    "key": "Celebrities"
                 }, {
                     "title": "Animals",
-                    "key": "General Knowledge"
+                    "key": "Animals"
                 }, {
                     "title": "Vehicles",
                     "key": "Vehicles"


### PR DESCRIPTION
Due to mismatch in the title and key of some categories, the user wouldn't always be taken to the category, they selected. It's fixed now.
